### PR TITLE
Fix #2: Add alpha color to cursor in command mode

### DIFF
--- a/main.css
+++ b/main.css
@@ -38,3 +38,9 @@
 .bottom-panel {
     z-index:4;
 }
+
+/* Fixes https://github.com/megalord/brackets-vim/issues/2 */
+.CodeMirror.cm-keymap-fat-cursor div.CodeMirror-cursor {
+    z-index: 100 !important;
+    background: rgba(67, 216, 145, 0.5) !important;
+}


### PR DESCRIPTION
Apparently it wasn’t a z-index issue at all. The cursor just needed a `rgba`-background to fix this _bug_.

![Screenshot](https://cloud.githubusercontent.com/assets/141435/3182392/3e65cee2-ec51-11e3-844d-7e0b2b12b871.png)
